### PR TITLE
Improved how function_def contexts are implemented

### DIFF
--- a/LuaExtended.sublime-syntax
+++ b/LuaExtended.sublime-syntax
@@ -1,12 +1,5 @@
 %YAML 1.2
 ---
-# http://www.sublimetext.com/docs/3/syntax.html
-#
-#        
-#        
-#        
-#        5: 
-#        6: 
 name: LuaExtended # by viluon
 comment: "LuaExtended Syntax: version 0.1"
 file_extensions:
@@ -77,7 +70,7 @@ contexts:
     - match: '(\()'
       captures:
         1: punctuation.definition.parameters.begin.lua
-      push: function_def_args
+      set: function_def_args
   function_def_args:
     - match: '([^)]*)'
       captures:
@@ -85,7 +78,7 @@ contexts:
     - match: '(\))'
       captures:
         1: punctuation.definition.parameters.end.lua
-      set: main
+      pop: true
   error_call:
     - match: "'"
       captures:


### PR DESCRIPTION
Previously, the function_def contexts worked like this:
- In the `main` context, when `function` was matched, `function_def_name` was pushed.
- In the `function_def_name` context, when `(` (function args start) was matched, `function_def_args` was pushed.
  - `function_def_name` was not popped, as you cannot `push` _and_ `pop` in the same match.
- In the `function_def_args` context, when `)` (function args end) was matched, the context `main` was set (as you cannot `pop` twice).

However, this broke compatibility with other syntaxes that use LuaExtended, such as @hbomb79's 'Titanium', which included `LuaExtended.sublime-syntax` in its `main` context.
After `function_def_args` matched `)`, the context would be set to **LuaExtended**'s main, not Titanium's. Titanium's `main` context would no longer work.

In order to fix this, I made a slight change:
- In the `main` context, when `function` is matched, `function_def_name` is pushed (same as before).
- In the `function_def_name` context, when `(` (function args start) is matched, `function_def_args` is **set**.
- In the `function_def_args` context, when `)` (function args end) is matched, `function_def_args` is popped.

This is a much nicer way to transition between the two contexts, and it worked perfectly when tested with @hbomb79's `Titanium.sublime_syntax`file.

On a different note, I also removed some leftover comments from 7708a4784b7e6b6a8093b35516fdf2698ae058aa that were meant to be temporary, but somehow made it into the commit (probably due to a faulty rebase). Sorry about that!